### PR TITLE
fixing compilation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "replug",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "description": "Auto-reverse engineer Plug.dj javascript",
   "repository": "ExtPlug/replug",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "esprima": "^2.0.0",
     "esrefactor": "*",
     "estraverse": "^1.9.1",
-    "jsdom": "3.x",
+    "jsdom": ">=6.x",
     "mkdirp": "*",
     "object-assign": "^3.0.0",
     "plug-login": "*",


### PR DESCRIPTION
After having struggled for days with being unable to `npm install` replug on neither Cygwin, nor my Debian server nor my Ubuntu VMs, I found this fix to actually get it to install.
Tested with iojs v3.3.1 in Cygwin and nodejs v4.0.0; though _running_ replug still didn't work in Cygwin due to node-progress.
